### PR TITLE
Export split and split_owned modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "asyncfd"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "libc",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asyncfd"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "Send and receive file descriptors over Unix domain sockets while maintaining Tokio AsyncRead and AsyncWrite"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 mod header;
-mod split;
-mod split_owned;
+pub mod split;
+pub mod split_owned;
 
 /// A wrapper around a `UnixStream` that allows file descriptors to be
 /// sent and received with messages.  Implements `AsyncRead` and


### PR DESCRIPTION
These modules define the types `ReadHalf`, `WriteHalf`, `OwnedReadHalf`, and `OwnedWriteHalf`. Currently, you can already get access to values of these types via `UnixFdStream`'s `split` and `into_split` methods but you cannot actually name the types as the modules defining them are not public.

This change makes the modules defining these types public allowing them to be named.